### PR TITLE
Modifica DecimalFormat per permettere fino a 8 decimali  (Campo PrezzoUnitario)

### DIFF
--- a/BaseClassSerializable.cs
+++ b/BaseClassSerializable.cs
@@ -26,7 +26,7 @@ namespace FatturaElettronica.Common
             XmlOptions = new XmlOptions()
             {
                 DateTimeFormat = "yyyy-MM-dd",
-                DecimalFormat = "0.00#################"
+                DecimalFormat = "0.00######"
             };
         }
         protected BaseClassSerializable(XmlReader r) : base() { ReadXml(r); }

--- a/BaseClassSerializable.cs
+++ b/BaseClassSerializable.cs
@@ -26,7 +26,7 @@ namespace FatturaElettronica.Common
             XmlOptions = new XmlOptions()
             {
                 DateTimeFormat = "yyyy-MM-dd",
-                DecimalFormat = "0.00###"
+                DecimalFormat = "0.00#################"
             };
         }
         protected BaseClassSerializable(XmlReader r) : base() { ReadXml(r); }

--- a/Test/JsonTest.cs
+++ b/Test/JsonTest.cs
@@ -12,10 +12,10 @@ namespace Test
         [TestMethod]
         public void JsonDeSerialize()
         {
-            var original = new TestMe { AString = "a string", ADate = DateTime.Now, ADecimal = 0.1234567m };
+            var original = new TestMe { AString = "a string", ADate = DateTime.Now, ADecimal = 0.12345678m };
             original.SubTestMe.AString = "a sub string";
             original.SubTestMe.ADate = DateTime.Now.AddDays(+1);
-            original.SubTestMe.ADecimal = 0.987654321m;
+            original.SubTestMe.ADecimal = 0.98765432m;
             var json = original.ToJson();
 
             Assert.IsFalse(json.Contains("XmlOptions"));

--- a/Test/JsonTest.cs
+++ b/Test/JsonTest.cs
@@ -12,9 +12,10 @@ namespace Test
         [TestMethod]
         public void JsonDeSerialize()
         {
-            var original = new TestMe { AString = "a string", ADate = DateTime.Now };
+            var original = new TestMe { AString = "a string", ADate = DateTime.Now, ADecimal = 0.1234567m };
             original.SubTestMe.AString = "a sub string";
             original.SubTestMe.ADate = DateTime.Now.AddDays(+1);
+            original.SubTestMe.ADecimal = 0.987654321m;
             var json = original.ToJson();
 
             Assert.IsFalse(json.Contains("XmlOptions"));
@@ -24,8 +25,10 @@ namespace Test
 
             Assert.AreEqual(original.AString, challenge.AString);
             Assert.AreEqual(original.ADate, challenge.ADate);
+            Assert.AreEqual(original.ADecimal, challenge.ADecimal);
             Assert.AreEqual(original.SubTestMe.AString, challenge.SubTestMe.AString);
             Assert.AreEqual(original.SubTestMe.ADate, challenge.SubTestMe.ADate);
+            Assert.AreEqual(original.SubTestMe.ADecimal, challenge.SubTestMe.ADecimal);
         }
     }
 }

--- a/Test/TestMe.cs
+++ b/Test/TestMe.cs
@@ -10,6 +10,8 @@ namespace Test
         [DataProperty]
         public DateTime ADate { get; set; }
         [DataProperty]
+        public decimal ADecimal { get; set; }
+        [DataProperty]
         public SubTestMe SubTestMe { get; } = new SubTestMe();
         public override void WriteXml(System.Xml.XmlWriter w)
         {
@@ -24,5 +26,7 @@ namespace Test
         public string AString { get; set; }
         [DataProperty]
         public DateTime ADate { get; set; }
+        [DataProperty]
+        public decimal ADecimal { get; set; }
     }
 }

--- a/Test/XmlTest.cs
+++ b/Test/XmlTest.cs
@@ -10,12 +10,13 @@ namespace Test
         [TestMethod]
         public void XmlDeSerialize()
         {
-            var original = new TestMe { AString = "a string", ADate = DateTime.Now };
+            var original = new TestMe { AString = "a string", ADate = DateTime.Now, ADecimal = 0.1234567m };
             original.SubTestMe.AString = "a sub string";
             original.SubTestMe.ADate = DateTime.Now.AddDays(+1);
+            original.SubTestMe.ADecimal = 0.987654321m;
 
-            var tempFile = "test.xml";
-            using (var w = XmlWriter.Create(tempFile ))
+           var tempFile = "test.xml";
+            using (var w = XmlWriter.Create(tempFile))
             {
                 original.WriteXml(w);
             }
@@ -28,8 +29,11 @@ namespace Test
 
             Assert.AreEqual(original.AString, challenge.AString);
             Assert.AreEqual(original.ADate.Date, challenge.ADate);
+            Assert.AreEqual(original.ADecimal, challenge.ADecimal);
             Assert.AreEqual(original.SubTestMe.AString, challenge.SubTestMe.AString);
             Assert.AreEqual(original.SubTestMe.ADate.Date, challenge.SubTestMe.ADate);
+            Assert.AreEqual(original.SubTestMe.ADate.Date, challenge.SubTestMe.ADate);
+            Assert.AreEqual(original.SubTestMe.ADecimal, challenge.SubTestMe.ADecimal);
         }
     }
 }

--- a/Test/XmlTest.cs
+++ b/Test/XmlTest.cs
@@ -10,10 +10,10 @@ namespace Test
         [TestMethod]
         public void XmlDeSerialize()
         {
-            var original = new TestMe { AString = "a string", ADate = DateTime.Now, ADecimal = 0.1234567m };
+            var original = new TestMe { AString = "a string", ADate = DateTime.Now, ADecimal = 0.12345678m };
             original.SubTestMe.AString = "a sub string";
             original.SubTestMe.ADate = DateTime.Now.AddDays(+1);
-            original.SubTestMe.ADecimal = 0.987654321m;
+            original.SubTestMe.ADecimal = 0.98765432m;
 
            var tempFile = "test.xml";
             using (var w = XmlWriter.Create(tempFile))


### PR DESCRIPTION
Buongiorno
Ho modificato il DecimalFormat  della classe BaseClassSerializable in modo che in fase di serializzazione di dati decimal siano permessi fino a 19 decimali.
La modifica serve per serializzazione in xml del campo PrezzoUnitario di DettaglioLinee: nel caso il valoreabbia più di 5 cifre decimali viene arrotondato provocando lo scarto da parte dello SDI con errore 00423 "PrezzoTotale non calcolato secondo le regole definite nelle specifiche tecniche"