### PR TITLE
Aggiunta al metodo IsEmpty regola per le proprietà di tipo DateTime

### DIFF
--- a/BaseClass.cs
+++ b/BaseClass.cs
@@ -86,6 +86,11 @@ namespace FatturaElettronica.Common
                     i++;
                     continue;
                 }
+                if (v is DateTime && v.Equals(DateTime.MinValue))
+                {
+                    i++;
+                    continue;
+                }
                 if (v is BaseClass && ((BaseClass)v).IsEmpty()) { 
                     i++;
                 }


### PR DESCRIPTION
Per poter validare oggetti contenenti date necessito di integrare il metodo IsEmpty con la validazione delle proprietà di tipo DateTime.